### PR TITLE
Allow underscores and dashes on camera IDs

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.23'
+        go-version: '1.24.1'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
The logging of errors when testing the config was improved.

Closes #7 